### PR TITLE
Dump v0.3 support

### DIFF
--- a/src/edump_dump.erl
+++ b/src/edump_dump.erl
@@ -16,20 +16,8 @@
 
 parse(Data) ->
     [Date | Lines] = edump_parse:lines(Data),
-    [{date, Date}
-     | [parse_line(L) || L <- Lines]].
+    [{date, Date} | [edump_parse:kv_line(L) || L <- Lines]].
 
 %%====================================================================
 %% Internal functions
 %%====================================================================
-
-parse_line(<<"Slogan: ", Slogan/binary>>) ->
-    {slogan, Slogan};
-parse_line(<<"System version: ", SystemVersion/binary>>) ->
-    {system_version, SystemVersion};
-parse_line(<<"Compiled: ", Date/binary>>) ->
-    {compiled, Date};
-parse_line(<<"Taints: ", Taints/binary>>) ->
-    {taints, Taints};
-parse_line(<<"Atoms: ", AtomsStr/binary>>) ->
-    {atoms, binary_to_integer(AtomsStr)}.

--- a/src/edump_ets.erl
+++ b/src/edump_ets.erl
@@ -34,4 +34,29 @@ parse_kv({<<"Words">>, V}) ->
     [{words, binary_to_integer(V)}];
 parse_kv({<<"Ordered set (AVL tree), Elements">>, V}) ->
     [{type, ord_set},
-     {elements, binary_to_integer(V)}].
+     {elements, binary_to_integer(V)}];
+parse_kv({<<"Chain Length Avg">>, F}) ->
+    [{chain_length_avg, binary_to_float(F)}];
+parse_kv({<<"Chain Length Max">>, V}) ->
+    [{chain_length_max, binary_to_integer(V)}];
+parse_kv({<<"Chain Length Min">>, V}) ->
+    [{chain_length_min, binary_to_integer(V)}];
+parse_kv({<<"Chain Length Std Dev">>, F}) ->
+    [{chain_length_stdev, binary_to_float(F)}];
+parse_kv({<<"Chain Length Expected Std Dev">>, F}) ->
+    [{chain_length_expected_stdev, binary_to_float(F)}];
+parse_kv({<<"Fixed">>, A}) ->
+    [{fixed, binary_to_existing_atom(A, latin1)}];
+parse_kv({<<"Type">>, A}) ->
+    [{type, binary_to_existing_atom(A, latin1)}];
+parse_kv({<<"Protection">>, A}) ->
+    [{protection, binary_to_existing_atom(A, latin1)}];
+parse_kv({<<"Compressed">>, A}) ->
+    [{compressed, binary_to_existing_atom(A, latin1)}];
+parse_kv({<<"Write Concurrency">>, A}) ->
+    [{write_concurrency, binary_to_existing_atom(A, latin1)}];
+parse_kv({<<"Read Concurrency">>, A}) ->
+    [{read_concurrency, binary_to_existing_atom(A, latin1)}];
+parse_kv({K, V}) ->
+    erlang:error({unknown_ets_info, {K, V}}).
+

--- a/src/edump_scheduler.erl
+++ b/src/edump_scheduler.erl
@@ -1,0 +1,47 @@
+-module(edump_scheduler).
+
+%% API exports
+-export([parse/1]).
+
+%%====================================================================
+%% API functions
+%%====================================================================
+
+%% =scheduler:3
+%% Scheduler Sleep Info Flags: 
+%% Scheduler Sleep Info Aux Work: 
+%% Current Port: 
+%% Run Queue Max Length: 0
+%% Run Queue High Length: 0
+%% Run Queue Normal Length: 0
+%% Run Queue Low Length: 0
+%% Run Queue Port Length: 0
+%% Run Queue Flags: OUT_OF_WORK | HALFTIME_OUT_OF_WORK | NONEMPTY | UNKNOWN(134217728)
+%% Current Process: <0.39.0>
+%% Current Process State: Running
+%% Current Process Internal State: ACT_PRIO_NORMAL | USR_PRIO_NORMAL | PRQ_PRIO_NORMAL | ACTIVE | RUNNING
+%% Current Process Program counter: 0x00000000194cf850 (unknown function)
+%% Current Process CP: 0x000000001a3bc458 (erl_eval:do_apply/6 + 376)
+%% Current Process Limited Stack Trace:
+%% 0x0000000019efcbe8:SReturn addr 0x1A37DE00 (shell:exprs/7 + 712)
+%% 0x0000000019efcc00:SReturn addr 0x1A37D4E8 (shell:eval_exprs/7 + 168)
+%% 0x0000000019efcc58:SReturn addr 0x1A37D0B8 (shell:eval_loop/3 + 592)
+%% 0x0000000019efcc90:SReturn addr 0x18069BF8 (<terminate process normally>)
+
+%% This section has a weird and irritating format,
+%% so we have do a crazy ish stateful parse.
+
+parse(Data) ->
+    lists:reverse(parse_lines(edump_parse:lines(Data), [])).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+parse_lines([], Acc) ->
+    Acc;
+parse_lines([<<"Current Process Limited Stack Trace:">> | Stack], Acc) ->
+    [{current_process_limited_stack_trace, Stack} | Acc];
+parse_lines([Line | Rest], Acc) ->
+    Acc1 = [edump_parse:kv_line(Line) | Acc],
+    parse_lines(Rest, Acc1).

--- a/src/edump_seg.erl
+++ b/src/edump_seg.erl
@@ -191,5 +191,7 @@ parse_data(binary, Data) ->
     [edump_parse:len_hexbin(Data)];
 parse_data(atoms, Data) ->
     [{atom, A} || A <- edump_parse:lines(Data)];
+parse_data(scheduler, Data) ->
+    edump_scheduler:parse(Data);
 parse_data('end', <<>>) ->
     [].


### PR DESCRIPTION
Erlang R18. something changed the dump format from v0.1 to v0.3. This PR adds backwards-compatible support for the new information.
