### PR TITLE
Use rebar3_erlydtl_plugin

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,13 +8,19 @@
                       {branch, "master"}}}
        ]}.
 
-{provider_hooks,
- [{post, [{compile, rdtl},
-          {rdtl, escriptize}]}]}.
+{provider_hooks, [
+    {pre, [{compile, {erlydtl, compile}}]}
+]}.
 
 {escript_name, "edump"}.
 {escript_incl_apps, [getopt]}.
 
-{plugins,
- [{rdtl, "",
-   {git, "https://github.com/archaelus/rdtl.git", {branch, "master"}}}]}.
+{plugins, [
+    {rebar3_erlydtl_plugin, 
+     {git, "https://github.com/tsloughter/rebar3_erlydtl_plugin.git", {branch, "master"}}}
+]}.
+
+{erlydtl_opts, [
+    {doc_root, "templates"},
+    {source_ext, ".rdtl"}
+]}.


### PR DESCRIPTION
This PR switches over to using the officially recommended rebar3 plugin for erlydtl, and simultaneously addresses an issue which prevents `edump` from compiling under Mix.

Mix uses `rebar3 bare compile --paths <path>`, and as far as I can tell, this prevents a post hook of `{compile, {default, escriptize}}` or `{compile, escriptize}` from working. The latter doesn't work at all (it complains about escriptize being unavailable), and the former fails during the escriptize task because it is unable to find the .app file for dependencies, since it is ignoring the bare configuration which overrides the paths (at least that's my assumption). It ends up looking in the local `_build/default/...` path, rather than in the path provided via `rebar3 bare compile --paths <path>`, and of course there is nothing there.

The fix for this last bit is to simply remove the escriptize hook for now, since I suspect it's not that important that it be automatically escriptized when compiling, and anyone who wants the escript can just run `rebar3 escriptize` themselves, and this allows other libraries to include edump. In my particular case, I want to provide a plugin for Distillery which includes `edump` in a release, and exposes a `bin/myapp edump <path to crash dump>` command. Right now I can't do that, since it isn't possible to compile a Mix project with `edump` as a dependency.

Let me know if you have any questions or concerns, I'm happy to help work it out!